### PR TITLE
chore(deps): reconcile pnpm lockfile overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,9 @@ overrides:
   defu: '>=6.1.5'
   aws-sdk: '>=2.1692.0'
   postcss: 8.5.10
-  next-contentlayer>next: 16.2.2
+  next-contentlayer>next: 16.2.0
   protobufjs: 7.5.5
-  next-contentlayer2>next: 16.2.2
+  next-contentlayer2>next: 16.2.0
 
 pnpmfileChecksum: sha256-xWy+VI/0lt8qlXFzRJyYtZr9c9UGPwirmDxGk4q80qM=
 
@@ -9892,7 +9892,7 @@ packages:
     resolution: {integrity: sha512-3Xh8quPCFmg/QGa4qTnOwSsT3oNYCtmm+Ii0UlbOHxX59gHYVX9M5mTzkdUKiKC1aJfiGIPPGQXhKNfc6qvWZg==}
     peerDependencies:
       contentlayer2: 0.5.8
-      next: 16.2.2
+      next: 16.2.0
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 


### PR DESCRIPTION
## Summary

This PR reconciles `pnpm-lock.yaml` with the committed `package.json` override configuration.

It fixes the lockfile/config mismatch that caused:

`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`

during frozen install.

## What changed

- Updated `pnpm-lock.yaml` only
- Reconciled `next-contentlayer>next` and `next-contentlayer2>next` override lockfile values
- Restored frozen-install consistency
- Restored local dependency resolution so `cookie` resolves correctly

## Verification

- `pnpm install --lockfile-only`: pass
- `pnpm install --frozen-lockfile`: pass
- `pnpm typecheck`: pass
- Installed `cookie`: `1.1.1`
- `@types/cookie` exposes `parse` and `serialize`
- No source files changed
- No deploy performed

## Notes

This PR should land before the isolated repo-hygiene PR, because the hygiene branch depends on a valid frozen-install baseline.

Do not merge the PR yet unless separately approved.