### PR TITLE
chore(build): generate mdx route manifest before link check

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:perimeter": "bash ./scripts/perimeter-check.sh",
     "audit:check": "tsc --noEmit ./lib/audit/audit-logger.ts ./lib/inner-circle/exports.server.ts ./lib/server/cron.ts",
     "build:analyze": "cross-env ANALYZE=true pnpm build",
-    "postbuild": "next-sitemap --config next-sitemap.config.mjs && node scripts/fix-sitemap-future-urls.mjs && node scripts/check-public-link-integrity.mjs",
+    "postbuild": "next-sitemap --config next-sitemap.config.mjs && node scripts/fix-sitemap-future-urls.mjs && node scripts/build-mdx-route-manifest.mjs && node scripts/check-public-link-integrity.mjs",
     "prebuild:ci": "pnpm vault:fix && pnpm fix:yaml && pnpm fix:windows && pnpm vault:ready",
     "build:pdfs:clean": "node -e \"console.log('build:pdfs:clean disabled (registry is committed)')\"",
     "build:pdfs": "node -e \"console.log('build:pdfs disabled (run pnpm pdf:build:full manually if needed)')\"",


### PR DESCRIPTION
## Summary

This PR fixes a pre-existing build lifecycle ordering bug.

`postbuild` runs `scripts/check-public-link-integrity.mjs`, which expects:

`reports/mdx-route-manifest.json`

But the normal build lifecycle did not generate that manifest first.

## What changed

- Updated `package.json` only
- Added `node scripts/build-mdx-route-manifest.mjs` before `node scripts/check-public-link-integrity.mjs` in `postbuild`
- Preserves the existing sitemap generation/fix steps before link integrity runs

## Verification

- `pnpm install --frozen-lockfile`: pass
- `pnpm mdx:integrity`: pass
- `pnpm mdx:gate`: pass
- `pnpm typecheck`: pass
- Isolated full build: pass
- Build exit code: 0
- `.next/BUILD_ID`: present
- `reports/mdx-route-manifest.json`: generated
- `check-public-link-integrity`: pass
- No source/runtime files changed
- No deploy performed

## Notes

This PR should land before the isolated repo-hygiene PR because it repairs the full-build baseline on `main`.