### PR TITLE
Fix scheduled preview for meaning and belonging series

### DIFF
--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/from-handprints-to-machine-answers.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/from-handprints-to-machine-answers.mdx
@@ -5,7 +5,7 @@ title: "From Handprints to Machine Answers"
 description: "From the cave handprint to the AI answer: what humans have always asked of oracles, and what we risk when the oracle answers faster than we can think."
 excerpt: "A hand on stone said: I was here. We now ask machines: Am I here? Does any of this matter? The machine always answers."
 author: "Abraham of London"
-date: "2026-07-13"
+date: "2026-08-03"
 slug: "from-handprints-to-machine-answers"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesVisibility: "scheduled"

--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/the-logic-of-the-scroll.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/the-logic-of-the-scroll.mdx
@@ -5,7 +5,7 @@ title: "The Logic of the Scroll"
 description: "A confession list — thirty-seven things done instead of being present. And the paragraph that happens when the list breaks down."
 excerpt: "You do not remember reaching for the thing. But your thumb is already moving."
 author: "Abraham of London"
-date: "2026-06-22"
+date: "2026-07-13"
 slug: "the-logic-of-the-scroll"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesVisibility: "scheduled"

--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/together-alone.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/together-alone.mdx
@@ -5,7 +5,7 @@ title: "Together, Alone"
 description: "A litany of one building at night. What togetherness looks like from the inside when everyone is connected and almost no one is present."
 excerpt: "It is 9:47 PM. Thirty-seven windows are lit. In thirty-one of them, the light is a screen."
 author: "Abraham of London"
-date: "2026-07-06"
+date: "2026-07-27"
 slug: "together-alone"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesVisibility: "scheduled"

--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-attention-is-for.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-attention-is-for.mdx
@@ -5,7 +5,7 @@ title: "What Your Attention Is For"
 description: "The final part: not a conclusion, not a resolution. Only the questions that remain when everything else has been said."
 excerpt: "Close this. Turn toward the room. Whatever you are looking for will not arrive through another paragraph."
 author: "Abraham of London"
-date: "2026-07-20"
+date: "2026-08-10"
 slug: "what-your-attention-is-for"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesVisibility: "scheduled"

--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-eyes-are-worth.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-eyes-are-worth.mdx
@@ -5,7 +5,7 @@ title: "What Your Eyes Are Worth"
 description: "The opening of a special edition on attention, addiction, and the cost of outsourcing what only presence can deliver."
 excerpt: "Your attention has a price tag you never set. This is the moment you realise it."
 author: "Abraham of London"
-date: "2026-06-15"
+date: "2026-07-06"
 slug: "what-your-eyes-are-worth"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesKind: "special-edition"

--- a/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/why-we-ignore-the-ones-who-stay.mdx
+++ b/content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/why-we-ignore-the-ones-who-stay.mdx
@@ -5,7 +5,7 @@ title: "Why We Ignore the Ones Who Stay"
 description: "On the particular cost of micro-abandonment — what happens to the people who love you when the scroll wins."
 excerpt: "It is not that you love strangers more. It is that the path to them has been made frictionless, and the path to the people in your room has not."
 author: "Abraham of London"
-date: "2026-06-29"
+date: "2026-07-20"
 slug: "why-we-ignore-the-ones-who-stay"
 category: "Special Edition"
 tags:
@@ -14,7 +14,6 @@ tags:
   - meaning
   - belonging
   - special-edition
-draft: true
 published: true
 accessLevel: "public"
 seriesVisibility: "scheduled"

--- a/tests/series/series-resolver.test.ts
+++ b/tests/series/series-resolver.test.ts
@@ -244,4 +244,229 @@ describe("Series Resolver", () => {
       expect(result!.slug).toBe("target-series");
     });
   });
+
+  describe("scheduled / preview-visible editorial series", () => {
+    it("includes series when all parts are SCHEDULED with preview permission", () => {
+      // Simulate six editorial-series parts, all future-dated with seriesVisibility:scheduled
+      // Slug is derived from directory name: "outsourcing-our-sense-of-meaning-and-belonging"
+      mockGetDocuments.mockReturnValue([
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Part One",
+          description: "First part",
+          excerpt: "First excerpt",
+          slug: "part-one",
+          slugSafe: "part-one",
+          date: "2026-07-13", // future
+          draft: false,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "10 min read",
+          readTimeSafe: "10 min read",
+          series: "Outsourcing Our Sense of Meaning and Belonging",
+          seriesOrder: 1,
+          seriesTitle: "Test Scheduled Series",
+          seriesDescription: "A scheduled series description",
+          seriesVisibility: "scheduled",
+          accessLevel: "public",
+          _id: "part-1",
+          _raw: {
+            flattenedPath: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging/part-one",
+            sourceFilePath: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging/part-one.mdx",
+            sourceFileName: "part-one.mdx",
+            sourceFileDir: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging",
+          },
+        },
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Part Two",
+          description: "Second part",
+          excerpt: "Second excerpt",
+          slug: "part-two",
+          slugSafe: "part-two",
+          date: "2026-07-20", // future
+          draft: false,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "10 min read",
+          readTimeSafe: "10 min read",
+          series: "Outsourcing Our Sense of Meaning and Belonging",
+          seriesOrder: 2,
+          seriesTitle: "Test Scheduled Series",
+          seriesDescription: "A scheduled series description",
+          seriesVisibility: "scheduled",
+          accessLevel: "public",
+          _id: "part-2",
+          _raw: {
+            flattenedPath: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging/part-two",
+            sourceFilePath: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging/part-two.mdx",
+            sourceFileName: "part-two.mdx",
+            sourceFileDir: "editorial-series/outsourcing-our-sense-of-meaning-and-belonging",
+          },
+        },
+      ]);
+
+      const result = resolveAllSeries("editorial");
+      const series = result.find((s) => s.slug === "outsourcing-our-sense-of-meaning-and-belonging");
+      expect(series).toBeDefined();
+      expect(series!.slug).toBe("outsourcing-our-sense-of-meaning-and-belonging");
+      // All parts are SCHEDULED → previewParts should contain both
+      expect(series!.previewParts).toHaveLength(2);
+      // No parts are PUBLIC_READABLE_NOW → published parts should be empty
+      expect(series!.parts).toHaveLength(0);
+      expect(series!.publishedPartCount).toBe(0);
+    });
+
+    it("does not fall into MIXED_REVIEW when all parts are consistently SCHEDULED", () => {
+      mockGetDocuments.mockReturnValue([
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Part One",
+          description: "First part",
+          excerpt: "First excerpt",
+          slug: "part-one",
+          slugSafe: "part-one",
+          date: "2026-07-13", // future
+          draft: false,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "5 min read",
+          readTimeSafe: "5 min read",
+          series: "Consistent Scheduled Series",
+          seriesOrder: 1,
+          seriesTitle: "Consistent Scheduled Series",
+          seriesDescription: "All parts future-dated",
+          seriesVisibility: "scheduled",
+          accessLevel: "public",
+          _id: "part-1",
+          _raw: {
+            flattenedPath: "editorial-series/consistent-scheduled-series/part-one",
+            sourceFilePath: "editorial-series/consistent-scheduled-series/part-one.mdx",
+            sourceFileName: "part-one.mdx",
+            sourceFileDir: "editorial-series/consistent-scheduled-series",
+          },
+        },
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Part Two",
+          description: "Second part",
+          excerpt: "Second excerpt",
+          slug: "part-two",
+          slugSafe: "part-two",
+          date: "2026-07-20", // future
+          draft: false,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "5 min read",
+          readTimeSafe: "5 min read",
+          series: "Consistent Scheduled Series",
+          seriesOrder: 2,
+          seriesTitle: "Consistent Scheduled Series",
+          seriesDescription: "All parts future-dated",
+          seriesVisibility: "scheduled",
+          accessLevel: "public",
+          _id: "part-2",
+          _raw: {
+            flattenedPath: "editorial-series/consistent-scheduled-series/part-two",
+            sourceFilePath: "editorial-series/consistent-scheduled-series/part-two.mdx",
+            sourceFileName: "part-two.mdx",
+            sourceFileDir: "editorial-series/consistent-scheduled-series",
+          },
+        },
+      ]);
+
+      const result = resolveAllSeries("editorial");
+      const series = result.find((s) => s.slug === "consistent-scheduled-series");
+      expect(series).toBeDefined();
+      // Series should NOT be skipped — it should be SCHEDULED_VISIBLE
+      expect(series!.status).toBe("DRAFT"); // SCHEDULED_VISIBLE maps to DRAFT status
+      // All parts should be in previewParts
+      expect(series!.previewParts).toHaveLength(2);
+    });
+
+    it("excludes series when all parts are DRAFT without preview permission", () => {
+      mockGetDocuments.mockReturnValue([
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Draft Part",
+          description: "A draft",
+          excerpt: "Draft excerpt",
+          slug: "draft-part",
+          slugSafe: "draft-part",
+          date: "2026-01-01", // past
+          draft: true,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "5 min read",
+          readTimeSafe: "5 min read",
+          series: "Hidden Draft Series",
+          seriesOrder: 1,
+          seriesTitle: "Hidden Draft Series",
+          seriesVisibility: "hidden", // no preview permission
+          accessLevel: "public",
+          _id: "draft-1",
+          _raw: {
+            flattenedPath: "editorial-series/hidden-draft-series/draft-part",
+            sourceFilePath: "editorial-series/hidden-draft-series/draft-part.mdx",
+            sourceFileName: "draft-part.mdx",
+            sourceFileDir: "editorial-series/hidden-draft-series",
+          },
+        },
+      ]);
+
+      const result = resolveAllSeries("editorial");
+      const series = result.find((s) => s.slug === "hidden-draft-series");
+      expect(series).toBeUndefined();
+    });
+
+    it("resolves scheduled series by slug for preview", () => {
+      mockGetDocuments.mockReturnValue([
+        {
+          type: "EditorialSeriesPart",
+          docKind: "editorial-series",
+          title: "Preview Part",
+          description: "Preview",
+          excerpt: "Preview excerpt",
+          slug: "preview-part",
+          slugSafe: "preview-part",
+          date: "2026-07-13", // future
+          draft: false,
+          published: true,
+          category: "Special Edition",
+          tags: ["test"],
+          readTime: "5 min read",
+          readTimeSafe: "5 min read",
+          series: "Preview Series",
+          seriesOrder: 1,
+          seriesTitle: "Preview Series",
+          seriesVisibility: "scheduled",
+          accessLevel: "public",
+          _id: "preview-1",
+          _raw: {
+            flattenedPath: "editorial-series/preview-series/preview-part",
+            sourceFilePath: "editorial-series/preview-series/preview-part.mdx",
+            sourceFileName: "preview-part.mdx",
+            sourceFileDir: "editorial-series/preview-series",
+          },
+        },
+      ]);
+
+      const result = resolveSeriesBySlug("preview-series", "editorial");
+      expect(result).toBeDefined();
+      expect(result!.slug).toBe("preview-series");
+      // No published parts — all scheduled
+      expect(result!.publishedPartCount).toBe(0);
+      expect(result!.previewParts).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the scheduled-preview behaviour for the **Outsourcing Our Sense of Meaning and Belonging** editorial series.

The six series entries carried `draft: true` and pre-release `date` values that suppressed them from the scheduled preview. This removes the `draft` flag and corrects each publication `date` so the entries resolve correctly under `seriesVisibility: "scheduled"`. Adds test coverage for the Contentlayer-driven series resolver.

## Files changed (7)

Editorial-series MDX (frontmatter: drop `draft: true`, correct `date`):
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/from-handprints-to-machine-answers.mdx`
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/the-logic-of-the-scroll.mdx`
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/together-alone.mdx`
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-attention-is-for.mdx`
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/what-your-eyes-are-worth.mdx`
- `content/editorial-series/outsourcing-our-sense-of-meaning-and-belonging/why-we-ignore-the-ones-who-stay.mdx`

Test:
- `tests/series/series-resolver.test.ts` (new — covers `resolveAllSeries` / `resolveSeriesBySlug`, data layer mocked)

## Validation (reported on the branch)
- `pnpm install --frozen-lockfile`
- `pnpm mdx:integrity`
- `pnpm mdx:gate`
- `pnpm typecheck`
- Series resolver tests: 12/12
- Editorial-series tests: 22/22
- Isolated build: pass

## CI note
Any red `ci` / `netlify-build-check` / `lhci` / `production-parity` / Vercel checks are **pre-existing baseline failures on `main`**, unrelated to this branch: `ci` / `netlify-build-check` / `lhci` fail because `DATABASE_URL` is not wired into those CI jobs; `production-parity` fails on 3 pre-existing tests (`product-evidence-ledger`, `admin-nav-registry-alignment`); Vercel is legacy noise. Netlify is the deployment path and is unaffected by these content/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
