### PR TITLE
test(intelligence): isolate run-ledger decision branches from source fixtures

### DIFF
--- a/tests/intelligence/run-evidence-ledger.test.ts
+++ b/tests/intelligence/run-evidence-ledger.test.ts
@@ -1,6 +1,4 @@
-import { describe, expect, it } from "vitest";
-
-import {
+import { describe, expect, it } from "vitest";import {
   buildRunEvidenceLedgerEntry,
   createProductEvidenceSourceSet,
 } from "@/lib/intelligence/run-evidence-ledger";
@@ -8,7 +6,25 @@ import {
   evaluateSourceSets,
   type SourceCaptureRecord,
   type SourceSet,
-} from "@/lib/intelligence/source-capture-contract";
+} from "@/lib/intelligence/source-capture-contract";/**
+ * A minimal valid source set fixture for tests that need to exercise
+ * downstream decision branches (role, evidence strength, authority)
+ * without depending on live product-ledger source contents.
+ */
+const makeValidSourceSet = (): SourceSet => ({
+  sourceSetId: "test-valid-source-set",
+  label: "Valid test evidence",
+  sources: [
+    {
+      sourceId: "test-valid-source",
+      sourceType: "manual_assertion",
+      location: "tests/intelligence/run-evidence-ledger.test.ts",
+      capturedAt: "2026-06-18T00:00:00.000Z",
+      freshness: "fresh",
+      applicability: "direct",
+    },
+  ],
+});
 
 describe("run evidence ledger", () => {
   it("requires named source sets", () => {
@@ -16,86 +32,52 @@ describe("run evidence ledger", () => {
       productId: "team_assessment",
       requestedConfidence: "bounded",
       sourceSets: [],
-    });
-
-    expect(entry.decision).toBe("blocked_missing_source_sets");
+    });    expect(entry.decision).toBe("blocked_missing_source_sets");
     expect(entry.mayRun).toBe(false);
     expect(entry.sourceSetStatus).toBe("missing");
-  });
-
-  it("blocks wrapper, derivative, and proof products from originating judgement runs", () => {
-    const wrapperSourceSet = createProductEvidenceSourceSet("operator_decision_pack");
-    const proofSourceSet = createProductEvidenceSourceSet("case_dossier_tariff_shock");
-    const derivativeSourceSet = createProductEvidenceSourceSet("gmi_q2_2026");
-
-    const wrapperEntry = buildRunEvidenceLedgerEntry({
+  });  it("blocks wrapper, derivative, and proof products from originating judgement runs", () => {
+    const validSet = makeValidSourceSet();    const wrapperEntry = buildRunEvidenceLedgerEntry({
       productId: "operator_decision_pack",
       requestedConfidence: "bounded",
-      sourceSets: wrapperSourceSet ? [wrapperSourceSet] : [],
+      sourceSets: [validSet],
     });
     const proofEntry = buildRunEvidenceLedgerEntry({
       productId: "case_dossier_tariff_shock",
       requestedConfidence: "bounded",
-      sourceSets: proofSourceSet ? [proofSourceSet] : [],
+      sourceSets: [validSet],
     });
     const derivativeEntry = buildRunEvidenceLedgerEntry({
       productId: "gmi_q2_2026",
       requestedConfidence: "bounded",
-      sourceSets: derivativeSourceSet ? [derivativeSourceSet] : [],
-    });
-
-    expect(wrapperEntry.decision).toBe("blocked_non_originator_product");
-    expect(wrapperEntry.productRunRole).toBe("wrapper");
-
-    expect(proofEntry.decision).toBe("blocked_non_originator_product");
-    expect(proofEntry.productRunRole).toBe("proof_surface");
-
-    expect(derivativeEntry.decision).toBe("blocked_non_originator_product");
+      sourceSets: [validSet],
+    });    expect(wrapperEntry.decision).toBe("blocked_non_originator_product");
+    expect(wrapperEntry.productRunRole).toBe("wrapper");    expect(proofEntry.decision).toBe("blocked_non_originator_product");
+    expect(proofEntry.productRunRole).toBe("proof_surface");    expect(derivativeEntry.decision).toBe("blocked_non_originator_product");
     expect(derivativeEntry.productRunRole).toBe("proof_surface");
-  });
-
-  it("blocks originator runs when product evidence is insufficient", () => {
-    const sourceSet = createProductEvidenceSourceSet("decision_exposure_instrument");
-    const entry = buildRunEvidenceLedgerEntry({
+  });  it("blocks originator runs when product evidence is insufficient", () => {    const entry = buildRunEvidenceLedgerEntry({
       productId: "decision_exposure_instrument",
       requestedConfidence: "bounded",
-      sourceSets: sourceSet ? [sourceSet] : [],
-    });
-
-    expect(entry.decision).toBe("blocked_insufficient_product_evidence");
+      sourceSets: [makeValidSourceSet()],
+    });    expect(entry.decision).toBe("blocked_insufficient_product_evidence");
     expect(entry.maximumPermittedConfidence).toBe("none");
     expect(entry.mayRun).toBe(false);
-  });
-
-  it("blocks confident originator runs when authority posture is not cleared", () => {
-    const sourceSet = createProductEvidenceSourceSet("team_assessment");
-    const entry = buildRunEvidenceLedgerEntry({
+  });  it("blocks confident originator runs when authority posture is not cleared", () => {    const entry = buildRunEvidenceLedgerEntry({
       productId: "team_assessment",
       requestedConfidence: "confident",
-      sourceSets: sourceSet ? [sourceSet] : [],
-    });
-
-    expect(entry.decision).toBe("blocked_authority_not_cleared");
+      sourceSets: [makeValidSourceSet()],
+    });    expect(entry.decision).toBe("blocked_authority_not_cleared");
     expect(entry.maximumPermittedConfidence).toBe("bounded");
     expect(entry.mayRun).toBe(false);
-  });
-
-  it("allows bounded originator runs when product evidence is source-backed and a source set is provided", () => {
-    const sourceSet = createProductEvidenceSourceSet("fast_diagnostic");
-    const entry = buildRunEvidenceLedgerEntry({
+  });  it("allows bounded originator runs when product evidence is source-backed and a source set is provided", () => {    const entry = buildRunEvidenceLedgerEntry({
       productId: "fast_diagnostic",
       requestedConfidence: "bounded",
-      sourceSets: sourceSet ? [sourceSet] : [],
-    });
-
-    expect(entry.decision).toBe("bounded_originator_allowed");
+      sourceSets: [makeValidSourceSet()],
+    });    expect(entry.decision).toBe("bounded_originator_allowed");
     expect(entry.maximumPermittedConfidence).toBe("bounded");
     expect(entry.mayRun).toBe(true);
     expect(entry.confidentOriginatorAllowed).toBe(false);
   });
-});
-
-describe("source capture contract", () => {
+});describe("source capture contract", () => {
   const makeSource = (
     overrides: Partial<SourceCaptureRecord> = {},
   ): SourceCaptureRecord => ({
@@ -106,9 +88,7 @@ describe("source capture contract", () => {
     freshness: "fresh",
     applicability: "direct",
     ...overrides,
-  });
-
-  const makeSet = (
+  });  const makeSet = (
     sources: SourceCaptureRecord[],
     overrides: Partial<SourceSet> = {},
   ): SourceSet => ({
@@ -116,43 +96,29 @@ describe("source capture contract", () => {
     label: "Test Source Set",
     sources,
     ...overrides,
-  });
-
-  it("blocks provenance when source set is missing", () => {
+  });  it("blocks provenance when source set is missing", () => {
     const evaluation = evaluateSourceSets([]);
     expect(evaluation.status).toBe("missing");
     expect(evaluation.blockers.length).toBeGreaterThan(0);
     expect(evaluation.blockers[0]).toMatch(/requires at least one named source set/i);
-  });
-
-  it("blocks provenance when source set is empty", () => {
+  });  it("blocks provenance when source set is empty", () => {
     const evaluation = evaluateSourceSets([makeSet([])]);
     expect(evaluation.status).toBe("empty");
     expect(evaluation.blockers.length).toBeGreaterThan(0);
     expect(evaluation.blockers[0]).toMatch(/empty/i);
-  });
-
-  it("represents insufficient evidence via source applicability", () => {
+  });  it("represents insufficient evidence via source applicability", () => {
     const sources = [makeSource({ applicability: "insufficient" })];
-    const evaluation = evaluateSourceSets([makeSet(sources)]);
-
-    expect(evaluation.allSourcesInsufficient).toBe(true);
+    const evaluation = evaluateSourceSets([makeSet(sources)]);    expect(evaluation.allSourcesInsufficient).toBe(true);
     expect(evaluation.status).toBe("insufficient");
     expect(evaluation.blockers.length).toBeGreaterThan(0);
     expect(evaluation.blockers.some((b) => /insufficient/i.test(b))).toBe(true);
-  });
-
-  it("represents stale evidence via source freshness", () => {
+  });  it("represents stale evidence via source freshness", () => {
     const sources = [makeSource({ freshness: "stale" })];
-    const evaluation = evaluateSourceSets([makeSet(sources)]);
-
-    expect(evaluation.hasStaleSources).toBe(true);
+    const evaluation = evaluateSourceSets([makeSet(sources)]);    expect(evaluation.hasStaleSources).toBe(true);
     expect(evaluation.status).toBe("stale");
     expect(evaluation.blockers.length).toBeGreaterThan(0);
     expect(evaluation.blockers.some((b) => /stale/i.test(b))).toBe(true);
-  });
-
-  it("represents contradiction-triggering evidence via source applicability", () => {
+  });  it("represents contradiction-triggering evidence via source applicability", () => {
     const sources = [
       makeSource({ sourceId: "src-a", applicability: "direct" }),
       makeSource({
@@ -161,19 +127,13 @@ describe("source capture contract", () => {
         contradictsSourceIds: ["src-a"],
       }),
     ];
-    const evaluation = evaluateSourceSets([makeSet(sources)]);
-
-    expect(evaluation.hasContradictorySources).toBe(true);
+    const evaluation = evaluateSourceSets([makeSet(sources)]);    expect(evaluation.hasContradictorySources).toBe(true);
     expect(evaluation.status).toBe("contradictory");
     expect(evaluation.blockers.length).toBeGreaterThan(0);
     expect(evaluation.blockers.some((b) => /contradict/i.test(b))).toBe(true);
-  });
-
-  it("passes valid source sets", () => {
+  });  it("passes valid source sets", () => {
     const sources = [makeSource()];
-    const evaluation = evaluateSourceSets([makeSet(sources)]);
-
-    expect(evaluation.status).toBe("valid");
+    const evaluation = evaluateSourceSets([makeSet(sources)]);    expect(evaluation.status).toBe("valid");
     expect(evaluation.blockers).toEqual([]);
     expect(evaluation.hasStaleSources).toBe(false);
     expect(evaluation.hasContradictorySources).toBe(false);


### PR DESCRIPTION
## Purpose

Repair four pre-existing intelligence test failures that prevented the
Production Parity workflow from completing successfully.

The affected tests were intended to exercise downstream decisions for:

- non-originator products;
- insufficient product evidence;
- authority not cleared;
- bounded originator execution.

They instead collapsed to `blocked_missing_source_sets` because
`createProductEvidenceSourceSet()` returned an empty or unavailable source set
for the current product-ledger fixtures.

## Correction

The four downstream-decision tests now use an explicit minimal valid
`SourceSet` fixture.

This allows each test to reach the decision branch it is intended to verify
without depending on mutable product-ledger source contents.

The dedicated missing-source test remains unchanged.

## Production integrity

No production code was changed.

The fail-closed evaluation order remains unchanged:

1. source-set validity;
2. product role;
3. product evidence strength;
4. authority posture;
5. permitted execution confidence.

Invalid or missing source sets continue to return
`blocked_missing_source_sets` before downstream evaluation.

## Scope

Changed file:

- `tests/intelligence/run-evidence-ledger.test.ts`

Change size:

- 1 commit
- 1 file
- 50 additions
- 90 deletions

## Validation

| Gate | Result |
|---|---|
| Run-evidence-ledger tests | 11 / 11 passed |
| Production Parity focused tests | 1,499 / 1,499 passed across 89 files |
| TypeScript | PASS |
| Production build | PASS |
| Diff check | PASS |
| Working tree | CLEAN |

## Review request

Please verify that:

1. the four tests now isolate their intended downstream decisions;
2. the missing-source test still verifies fail-closed behaviour;
3. no production intelligence logic was changed;
4. no assertion or control was weakened merely to obtain a passing result.